### PR TITLE
"Not Working"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Let's say we want to work on a project named `MyProject` base on three dependenc
     |MyProject/                         // this is the project we currently work on
                                         // which depends on other three packages
 
+Note: `MyVendor/MyPackage1` and `MyVendor\MyPackage2` must exist in some composer repository
+already before they can be considered by composer to be installed or symlinked.  Typically,
+packages will already be accessible via Packagist.  But if they are local only (no already
+configured repository) then a local one will need to be added to your composer.json.
+It might look like this:
+
+      "repositories": [
+        {
+          "type":"vcs",
+          "url":"/path/to/DOCUMENT_ROOT/projects/MyVendor/MyPackage1"
+        }
+      ]
 
 As we want to work on both *MyProject* and its dependencies *MyPackageX*, we would usually 
 first install our dependencies with Composer (as hard copies), to let it create a valid 

--- a/src/ComposerSymlinker/LocalInstaller.php
+++ b/src/ComposerSymlinker/LocalInstaller.php
@@ -114,7 +114,7 @@ class LocalInstaller extends LibraryInstaller
     {
         $local_path = $this->getLocalPackagePath($package);
         if (!is_null($local_path)) {
-            $this->io->writeError("  - Installing <info>" . $package->getName() . "</info> (<comment>as a symbolic link of " . $local_path . "</comment>)");
+            $this->io->write("  - Installing <info>" . $package->getName() . "</info> (<comment>as a symbolic link of " . $local_path . "</comment>)");
             $this->initializeVendorSubdir($package);
             if (true !== @symlink($local_path, $this->getInstallPath($package))) {
                 throw new FilesystemSymlinkerException(


### PR DESCRIPTION
I hate when people just say its "not working" but I don't have enough experience with composer plugins to be able to be of specific help.

I've set breakpoints on all the public methods inside LocalInstaller and outside of construction, the class is never consulted.  I've added the following to my composer.json's extra section:

``` js
    "local-dirs": "/Users/ralphschindler/Projects/distillphp",
    "local-packages": {
      "distill/mapper": "/Users/ralphschindler/Projects/distillphp/distill-mapper"
    }
```

I can see the constructor is working, and the state of the object seems correct at the end of construction:
But then LocalInstaller is never asked to install/symlink anything.

~~Does the target package have to exist in a repository first? Like inside packagist or a local repository?~~

Update: Yes, a local repository is required if it is not already in another repository.  Also, I'll turn this into a PR for an update to the README, and another issue I found.
